### PR TITLE
Changed generic yaml/json file matching to a regex that includes .concat

### DIFF
--- a/lib/concat.js
+++ b/lib/concat.js
@@ -20,7 +20,14 @@ module.exports = function( _, anvil ) {
 		list: [],
 		translated: false,
 
+		rFileMatch: null,
+		config: {
+			fileMatch: "\\.concat\\.(ya?ml|json)$"
+		},
+
 		configure: function( config, command, done ) {
+			this.rFileMatch = new RegExp( config[ "anvil.concat" ].fileMatch );
+
 			if( !yaml ) {
 				yaml = require( "yaml-js" );
 			}
@@ -33,11 +40,9 @@ module.exports = function( _, anvil ) {
 
 		cleanup: function( done ) {
 			var files =	_.filter( anvil.project.files, function( file ) { return file.concat; } );
+			var self = this;
 			anvil.scheduler.parallel( files, function( file, done ) {
-				var newName = file.name
-								.replace( ".yml", "" )
-								.replace( ".yaml", "" )
-								.replace( ".json", "" );
+				var newName = file.name.replace( self.rFileMatch, "" );
 				anvil.fs.rename(
 					[ file.workingPath, file.name ],
 					[ file.workingPath, newName ],
@@ -111,24 +116,25 @@ module.exports = function( _, anvil ) {
 
 		transformFiles: function( done ) {
 			var self = this;
-			anvil.scheduler.parallel( anvil.project.files, function( file, done) {
+
+			var files = _.filter( anvil.project.files, function ( file ) {
+				return self.rFileMatch.test( file.name );
+			});
+
+			anvil.scheduler.parallel( files, function( file, done) {
 				var ext = file.extension();
-				if( ext === ".yml" || ext === ".yaml" || ext === ".json" ) {
-					anvil.fs.read( [ file.workingPath, file.name ], function( content, error ) {
-						if( !error ) {
-							if( ext === ".yml" || ext === ".yaml" ) {
-								self.transformYaml( file, content, done );
-							} else if ( ext === ".json" ) {
-								self.transformJson( file, content, done );
-							} else {
-								done();
-							}
+				anvil.fs.read( [ file.workingPath, file.name ], function( content, error ) {
+					if( !error ) {
+						if( ext === ".yml" || ext === ".yaml" ) {
+							self.transformYaml( file, content, done );
+						} else if ( ext === ".json" ) {
+							self.transformJson( file, content, done );
+						} else {
+							done();
 						}
-						done();
-					} );
-				} else {
+					}
 					done();
-				}
+				} );
 			}, done );
 		},
 

--- a/src/concat.js
+++ b/src/concat.js
@@ -11,7 +11,14 @@ module.exports = function( _, anvil ) {
 		list: [],
 		translated: false,
 
+		rFileMatch: null,
+		config: {
+			fileMatch: "\\.concat\\.(ya?ml|json)$"
+		},
+
 		configure: function( config, command, done ) {
+			this.rFileMatch = new RegExp( config[ "anvil.concat" ].fileMatch );
+
 			if( !yaml ) {
 				yaml = require( "yaml-js" );
 			}
@@ -24,11 +31,9 @@ module.exports = function( _, anvil ) {
 
 		cleanup: function( done ) {
 			var files =	_.filter( anvil.project.files, function( file ) { return file.concat; } );
+			var self = this;
 			anvil.scheduler.parallel( files, function( file, done ) {
-				var newName = file.name
-								.replace( ".yml", "" )
-								.replace( ".yaml", "" )
-								.replace( ".json", "" );
+				var newName = file.name.replace( self.rFileMatch, "" );
 				anvil.fs.rename(
 					[ file.workingPath, file.name ],
 					[ file.workingPath, newName ],
@@ -102,24 +107,25 @@ module.exports = function( _, anvil ) {
 
 		transformFiles: function( done ) {
 			var self = this;
-			anvil.scheduler.parallel( anvil.project.files, function( file, done) {
+
+			var files = _.filter( anvil.project.files, function ( file ) {
+				return self.rFileMatch.test( file.name );
+			});
+
+			anvil.scheduler.parallel( files, function( file, done) {
 				var ext = file.extension();
-				if( ext === ".yml" || ext === ".yaml" || ext === ".json" ) {
-					anvil.fs.read( [ file.workingPath, file.name ], function( content, error ) {
-						if( !error ) {
-							if( ext === ".yml" || ext === ".yaml" ) {
-								self.transformYaml( file, content, done );
-							} else if ( ext === ".json" ) {
-								self.transformJson( file, content, done );
-							} else {
-								done();
-							}
+				anvil.fs.read( [ file.workingPath, file.name ], function( content, error ) {
+					if( !error ) {
+						if( ext === ".yml" || ext === ".yaml" ) {
+							self.transformYaml( file, content, done );
+						} else if ( ext === ".json" ) {
+							self.transformJson( file, content, done );
+						} else {
+							done();
 						}
-						done();
-					} );
-				} else {
+					}
 					done();
-				}
+				} );
 			}, done );
 		},
 


### PR DESCRIPTION
Instead of hardcoding the convention, I moved it to a regex that could be overridden in build.json. 

We didn't discuss this large a change, so I am totally open to handling it differently. As it stands now, it will only process files that end in `.concat.(ya?ml|json)`.
